### PR TITLE
feat: Add file size and relax column count type

### DIFF
--- a/client/components/GridView.tsx
+++ b/client/components/GridView.tsx
@@ -2,7 +2,7 @@ import { getThumbnailUrl, Video } from "../api";
 import { useVideoContext } from "../contexts/video";
 
 type GridViewProps = {
-  columns: 2 | 3 | 4 | 5;
+  columns: number;
   videos: Video[];
 };
 

--- a/client/types.ts
+++ b/client/types.ts
@@ -1,7 +1,7 @@
 export type ViewMode =
   | { mode: "list" }
   | { mode: "feed" }
-  | { mode: "grid"; columns: 2 | 3 | 4 | 5 };
+  | { mode: "grid"; columns: number };
 export type Filter =
   | { mode: "none" }
   | { mode: "tagless" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "video-sort-ai",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/common.rs
+++ b/src/common.rs
@@ -16,6 +16,7 @@ pub struct Video {
     pub tags: HashSet<String>,
     pub note: String,
     pub mtime: SystemTime,
+    pub size: u64,
     /// currently unused, but will be used for stowing videos in Termux to avoid
     /// persecution by Google Photos
     pub stow_state: StowState,

--- a/src/register.rs
+++ b/src/register.rs
@@ -41,7 +41,9 @@ pub async fn add_videos(path: &str, state: SharedState) -> MyResult<()> {
                     .file_name()
                     .map(|s| s.to_string_lossy())
                     .unwrap_or_default();
-                let mtime = metadata(&path).await?.modified()?;
+                let metadata = metadata(&path).await?;
+                let mtime = metadata.modified()?;
+                let size = metadata.len();
                 let thumbnail_name = format!(
                     "{}.jpg",
                     sanitize_filename::sanitize(path.as_os_str().to_string_lossy())
@@ -73,6 +75,7 @@ pub async fn add_videos(path: &str, state: SharedState) -> MyResult<()> {
                         tags: HashSet::new(),
                         note: String::new(),
                         mtime,
+                        size,
                         stow_state: StowState::Original,
                     });
                 }


### PR DESCRIPTION
This commit introduces two new features:

1.  The CLI now collects the file size of added video files, similar to how `mtime` is collected. The `Video` struct has been updated to include a `size` field, and the `add_videos` function now populates this field.

2.  The type for the grid view's column count has been relaxed from a union of literals to `number`. This change affects the `ViewMode` type in `client/types.ts` and the `GridViewProps` in `client/components/GridView.tsx`.